### PR TITLE
Add optional MDBList collection sync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,10 @@ ENV PYTHONUNBUFFERED=1
 ENV PYTHONDONTWRITEBYTECODE=1
 WORKDIR /usr/src/app
 COPY ./requirements.txt .
-COPY ./mdblistarr /usr/src/app/
 RUN pip install --upgrade pip
 RUN pip install -r requirements.txt
 RUN apt-get update
+COPY ./mdblistarr /usr/src/app/
 RUN mkdir -p /usr/src/db/
 ENV PORT=5353
 EXPOSE 5353

--- a/mdblistarr/mdblistrr/arr.py
+++ b/mdblistarr/mdblistrr/arr.py
@@ -79,6 +79,12 @@ class SonarrAPI():
         except Exception as e:
             return [{'result': f'Error connecting to Sonarr API (importlistexclusion): {str(e)}'}]
     
+    def get_episodes(self, series_id):
+        try:
+            return self.connect.get_json(f"{self.url}/api/v3/episode", params={"apikey": self.apikey, "seriesId": series_id})
+        except Exception as e:
+            return [{'result': f'Error connecting to Sonarr API (episode): {str(e)}'}]
+
     def post_show(self, payload):
         try:
             return self.connect.post_json(f"{self.url}/api/v3/series", json=payload, params={"apikey": self.apikey})
@@ -239,6 +245,18 @@ class MdblistAPI():
             return(self.connect.post_json(f"{self.url}/service/mdblist/arr", json=payload, params={"apikey": self.apikey}))
         except:
             return {'response': f'{traceback.format_exc()}'}
+
+    def post_collection(self, payload):
+        try:
+            return self.connect.post_json(f"https://api.mdblist.com/sync/collection", json=payload, params={"apikey": self.apikey})
+        except:
+            return {'error': f'{traceback.format_exc()}'}
+
+    def post_collection_remove(self, payload):
+        try:
+            return self.connect.post_json(f"https://api.mdblist.com/sync/collection/remove", json=payload, params={"apikey": self.apikey})
+        except:
+            return {'error': f'{traceback.format_exc()}'}
 
     def get_mdblist_queue(self):
         try:

--- a/mdblistarr/mdblistrr/cron.py
+++ b/mdblistarr/mdblistrr/cron.py
@@ -6,7 +6,7 @@ import time
 import json
 import random
 import traceback
-from .models import Log, InstanceChangeLog, RadarrInstance, SonarrInstance
+from .models import Log, InstanceChangeLog, RadarrInstance, SonarrInstance, Preferences
 from .services import get_mdblistarr
 from .arr import SonarrAPI
 from .arr import RadarrAPI
@@ -26,6 +26,9 @@ def post_radarr_payload():
         if mdblistarr.mdblist is None:
             save_log(1, 2, "MDBList API key not configured")
             return {"response": "Missing API key"}
+        sync_library_pref = Preferences.objects.filter(name='sync_library_status').first()
+        sync_library = sync_library_pref and sync_library_pref.value == '1'
+
         radarr_api = RadarrAPI()
         movies = radarr_api.get_movies()
         exclusions = radarr_api.get_exclusions()
@@ -94,10 +97,41 @@ def post_radarr_payload():
 
         if res.get('response') == 'Ok':
             save_log(provider, 1, f'{radarr_api.name}: Uploaded {total_records} records to MDBList.com (excluded={excluded_count})')
-            return res
         else:
             save_log(provider, 2, f'Upload records to MDBList.com Failed: {res}')
             return res
+
+        # Sync collection (library status) if enabled.
+        if sync_library:
+            save_log(provider, 3, f'{radarr_api.name}: Starting collection sync')
+            collection_add = []
+            collection_remove = []
+            for rec in records:
+                item = {'ids': {'tmdb': rec['tmdb']}}
+                if rec.get('exists'):
+                    collection_add.append(item)
+                elif rec.get('exists') is False:
+                    collection_remove.append(item)
+
+            save_log(provider, 3, f'{radarr_api.name}: Collection sync: {len(collection_add)} downloaded, {len(collection_remove)} undownloaded')
+
+            if collection_add:
+                add_res = mdblistarr.mdblist.post_collection({'movies': collection_add})
+                if isinstance(add_res, dict) and add_res.get('error'):
+                    save_log(provider, 2, f'{radarr_api.name}: Collection add failed: {add_res}')
+                else:
+                    added = add_res.get('updated', {}).get('movies', 0) if isinstance(add_res, dict) else 0
+                    save_log(provider, 1, f'{radarr_api.name}: Synced {added} movies to MDBList collection')
+
+            if collection_remove:
+                rm_res = mdblistarr.mdblist.post_collection_remove({'movies': collection_remove})
+                if isinstance(rm_res, dict) and rm_res.get('error'):
+                    save_log(provider, 2, f'{radarr_api.name}: Collection remove failed: {rm_res}')
+                else:
+                    removed = rm_res.get('removed', {}).get('movies', 0) if isinstance(rm_res, dict) else 0
+                    save_log(provider, 1, f'{radarr_api.name}: Ensured {removed} undownloaded movies are not in MDBList collection')
+
+        return res
     except:
         save_log(provider, 2, f'{traceback.format_exc()}')
         return {'response': 'Exception'}
@@ -114,6 +148,9 @@ def post_sonarr_payload():
         if mdblistarr.mdblist is None:
             save_log(2, 2, "MDBList API key not configured")
             return {"response": "Missing API key"}
+        sync_library_pref = Preferences.objects.filter(name='sync_library_status').first()
+        sync_library = sync_library_pref and sync_library_pref.value == '1'
+
         sonarr_api = SonarrAPI()
         series = sonarr_api.get_series()
         exclusions = sonarr_api.get_import_list_exclusions()
@@ -132,6 +169,7 @@ def post_sonarr_payload():
             return {"response": "SonarrError"}
 
         records_by_tvdb = {}
+        series_id_to_tvdb = {}
 
         # Library state (downloaded/missing).
         for show in series if isinstance(series, list) else []:
@@ -140,6 +178,10 @@ def post_sonarr_payload():
             tvdb_id = show.get('tvdbId')
             if not tvdb_id:
                 continue
+
+            sonarr_id = show.get('id')
+            if sonarr_id is not None:
+                series_id_to_tvdb[sonarr_id] = tvdb_id
 
             # Prefer series-level statistics when present.
             # We consider "downloaded" if there is at least 1 episode file.
@@ -203,10 +245,74 @@ def post_sonarr_payload():
         res = mdblistarr.mdblist.post_arr_payload(json_payload)
         if res.get('response') == 'Ok':
             save_log(provider, 1, f'{sonarr_api.name}: Uploaded {total_records} records to MDBList.com (excluded={excluded_count})')
-            return res
         else:
             save_log(provider, 2, f'Upload records to MDBList.com Failed: {res}')
             return res
+
+        # Sync collection (library status) if enabled.
+        # For shows we need episode-level data so we don't incorrectly mark
+        # entire shows as collected when only some episodes have files.
+        if sync_library:
+            save_log(provider, 3, f'{sonarr_api.name}: Starting collection sync')
+            collection_add = []
+            collection_remove = []
+            total_episodes_collected = 0
+
+            for sonarr_id, tvdb_id in series_id_to_tvdb.items():
+                rec = records_by_tvdb.get(tvdb_id)
+                if not rec:
+                    continue
+
+                if not rec.get('exists'):
+                    collection_remove.append({'ids': {'tvdb': tvdb_id}})
+                    continue
+
+                episodes = sonarr_api.get_episodes(sonarr_id)
+                if not isinstance(episodes, list):
+                    save_log(provider, 2, f'{sonarr_api.name}: Failed to fetch episodes for series {sonarr_id} (tvdb={tvdb_id})')
+                    continue
+
+                seasons_map = {}
+                for ep in episodes:
+                    if not isinstance(ep, dict):
+                        continue
+                    if not ep.get('hasFile'):
+                        continue
+                    season_num = ep.get('seasonNumber')
+                    ep_num = ep.get('episodeNumber')
+                    if season_num is None or ep_num is None:
+                        continue
+                    seasons_map.setdefault(season_num, []).append({'number': ep_num})
+
+                if seasons_map:
+                    total_episodes_collected += sum(len(eps) for eps in seasons_map.values())
+                    collection_add.append({
+                        'ids': {'tvdb': tvdb_id},
+                        'seasons': [
+                            {'number': s_num, 'episodes': eps}
+                            for s_num, eps in sorted(seasons_map.items())
+                        ]
+                    })
+
+            save_log(provider, 3, f'{sonarr_api.name}: Collection sync: {len(collection_add)} shows ({total_episodes_collected} episodes) downloaded, {len(collection_remove)} undownloaded')
+
+            if collection_add:
+                add_res = mdblistarr.mdblist.post_collection({'shows': collection_add})
+                if isinstance(add_res, dict) and add_res.get('error'):
+                    save_log(provider, 2, f'{sonarr_api.name}: Collection add failed: {add_res}')
+                else:
+                    updated = add_res.get('updated', {}) if isinstance(add_res, dict) else {}
+                    save_log(provider, 1, f'{sonarr_api.name}: Synced collection (shows={updated.get("shows", 0)} seasons={updated.get("seasons", 0)} episodes={updated.get("episodes", 0)})')
+
+            if collection_remove:
+                rm_res = mdblistarr.mdblist.post_collection_remove({'shows': collection_remove})
+                if isinstance(rm_res, dict) and rm_res.get('error'):
+                    save_log(provider, 2, f'{sonarr_api.name}: Collection remove failed: {rm_res}')
+                else:
+                    removed = rm_res.get('removed', {}).get('shows', 0) if isinstance(rm_res, dict) else 0
+                    save_log(provider, 1, f'{sonarr_api.name}: Ensured {removed} undownloaded shows are not in MDBList collection')
+
+        return res
     except:
         save_log(provider, 2, f'{traceback.format_exc()}')
         return {'response': 'Exception'}

--- a/mdblistarr/mdblistrr/views.py
+++ b/mdblistarr/mdblistrr/views.py
@@ -19,14 +19,20 @@ logger = logging.getLogger(__name__)
 
 class MDBListForm(forms.Form):
     mdblist_apikey = forms.CharField(
-        label='MDBList API Key', 
+        label='MDBList API Key',
         widget=forms.TextInput(attrs={'placeholder': 'Enter your mdblist.com API key', 'class': 'form-control'})
+    )
+    sync_library_status = forms.BooleanField(
+        label='Sync Library Status',
+        required=False,
+        widget=forms.CheckboxInput(attrs={'class': 'form-check-input'}),
+        help_text='Also update your MDBList Library status based on your Sonarr/Radarr library.'
     )
 
     def clean(self):
         cleaned_data = super().clean()
         mdblist_apikey = cleaned_data.get('mdblist_apikey')
-        
+
         if mdblist_apikey:
             mdblistarr = get_mdblistarr()
             if mdblistarr.mdblist is None:
@@ -34,11 +40,10 @@ class MDBListForm(forms.Form):
             if not mdblistarr.mdblist.test_api(mdblist_apikey):
                 self._errors['mdblist_apikey'] = self.error_class(['API key is invalid, unable to connect'])
                 self.fields['mdblist_apikey'].widget.attrs.update({'class': 'form-control is-invalid'})
-                # self.add_error(None, "API key is invalid. Unable to save changes.")
 
             else:
                 self.fields['mdblist_apikey'].widget.attrs.update({'class': 'form-control is-valid'})
-        
+
         return cleaned_data
 
 class ServerSelectionForm(forms.Form):
@@ -125,7 +130,9 @@ class SonarrInstanceForm(forms.ModelForm):
 
 def home_view(request):
     mdblistarr = get_mdblistarr()
-    mdblist_form = MDBListForm(initial={'mdblist_apikey': mdblistarr.mdblist_apikey})
+    sync_library_pref = Preferences.objects.filter(name='sync_library_status').first()
+    sync_library_status = sync_library_pref and sync_library_pref.value == '1'
+    mdblist_form = MDBListForm(initial={'mdblist_apikey': mdblistarr.mdblist_apikey, 'sync_library_status': sync_library_status})
     
     radarr_instances = RadarrInstance.objects.all()
     sonarr_instances = SonarrInstance.objects.all()
@@ -158,8 +165,12 @@ def home_view(request):
             mdblist_form = MDBListForm(request.POST)
             if mdblist_form.is_valid():
                 Preferences.objects.update_or_create(
-                    name='mdblist_apikey', 
+                    name='mdblist_apikey',
                     defaults={'value': mdblist_form.cleaned_data['mdblist_apikey']}
+                )
+                Preferences.objects.update_or_create(
+                    name='sync_library_status',
+                    defaults={'value': '1' if mdblist_form.cleaned_data.get('sync_library_status') else '0'}
                 )
                 reset_mdblistarr()
                 mdblistarr = get_mdblistarr()

--- a/mdblistarr/templates/index.html
+++ b/mdblistarr/templates/index.html
@@ -51,6 +51,11 @@
                             {% if not mdblist_form.errors %}API key validated successfully{% else %}{{ mdblist_form.mdblist_apikey.help_text }}{% endif %}
                         </div>
                     </div>
+                    <div class="fieldWrapper mb-3 form-check">
+                        {{ mdblist_form.sync_library_status }}
+                        {{ mdblist_form.sync_library_status.label_tag }}
+                        <div class="form-text">{{ mdblist_form.sync_library_status.help_text }}</div>
+                    </div>
                 </div>
                 <div class="d-grid gap-2 d-md-flex mb-4">
                     <input class="btn btn-success" type="submit" value="Save MDBList Configuration">

--- a/mdblistarr/templates/log.html
+++ b/mdblistarr/templates/log.html
@@ -19,7 +19,7 @@
     {% for log in logs %}
       <tr>
         <th scope="row">{% if log.provider == 1 %}Radarr{% elif log.provider == 2 %}Sonarr{% elif log.provider == 3 %}Config{% else %}{{ log.provider }}{% endif %}</td>
-        <th {% if log.status == 1 %}class="badge text-bg-success"{% elif log.status == 2 %}class="badge text-bg-warning"{% elif log.status == 3 %}class="badge text-bg-secondary"{% endif %}>{% if log.status == 1 %}Success{% else %}Warning{% endif %}</th>
+        <th {% if log.status == 1 %}class="badge text-bg-success"{% elif log.status == 2 %}class="badge text-bg-warning"{% elif log.status == 3 %}class="badge text-bg-secondary"{% endif %}>{% if log.status == 1 %}Success{% elif log.status == 3 %}Info{% else %}Warning{% endif %}</th>
         <td nowrap="nowrap">{{ log.date|date:"Y-m-d H:i:s" }}</th>
         <td>{{log.text}}</td>
       </tr>


### PR DESCRIPTION
<img width="1238" height="642" alt="2026-04-12 at 12 33 55@2x" src="https://github.com/user-attachments/assets/a1728bee-6c72-4865-8a40-67de4d254cc3" />

- Adds a "Sync Library Status" option that syncs your Radarr/Sonarr library to the MDBList /sync/collection endpoint, so items show as collected on MDBList
- Radarr syncs at movie level using tmdb IDs
- Sonarr syncs at episode level, fetching per-episode hasFile data from the Sonarr API to accurately mark only downloaded episodes
- Includes a Dockerfile improvement for better layer caching and a minor log display fix

### Notes

- The collection sync runs as part of the existing daily scheduled sync, after the arr payload upload
- Only runs when the checkbox is enabled (off by default)
- Built with Claude Code

Issues

- Seasons/Shows are not marked as collected, only episodes